### PR TITLE
DR-25 nodemon legacy mode for docker, make init functions consistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services: 
     declutter-reddit:
         build: . 
-        command: ./node_modules/.bin/nodemon --inspect=0.0.0.0:9229 -r dotenv/config server.js
+        command: ./node_modules/.bin/nodemon -L --inspect=0.0.0.0:9229 -r dotenv/config server.js
         volumes: 
             - .:/usr/src/app
         ports: 

--- a/lib/utils/debug.js
+++ b/lib/utils/debug.js
@@ -2,7 +2,7 @@ const debug = require('debug');
 
 let loggers;
 
-function initDebug() {
+function init() {
   const debugServer = debug('debug:server');
   const debugRequest = debug('debug:request-error');
   const debugDatabase = debug('debug:database');
@@ -31,7 +31,7 @@ function logRequest(...message) {
 }
 
 module.exports = {
-  initDebug,
+  init,
   getLogger,
   logServer,
   logDatabase,

--- a/server.js
+++ b/server.js
@@ -2,9 +2,9 @@ const express = require('express');
 const session = require('express-session');
 const config = require('config');
 
-const knex = require('./lib/database/knex');
-const objection = require('./lib/database/objection');
-const { initDebug, logServer } = require('./lib/utils/debug');
+const { init: initKnex, getInstance: getKnexInstance } = require('./lib/database/knex');
+const { init: initObjection } = require('./lib/database/objection');
+const { init: initDebug, logServer } = require('./lib/utils/debug');
 const router = require('./lib/router');
 
 function initMiddlewares(app) {
@@ -21,10 +21,12 @@ function initMiddlewares(app) {
 function initApp() {
   const { PORT } = config.get('app');
   const app = express();
+  const knex = getKnexInstance;
 
   // Add migration runner here
-  knex.init();
-  objection.init(knex.getInstance());
+
+  initKnex();
+  initObjection(knex());
   initDebug();
   initMiddlewares(app);
 

--- a/test/unit/server.test.js
+++ b/test/unit/server.test.js
@@ -1,5 +1,5 @@
 describe('Sample Test', () => {
-    it('Sample test', () => {
-        expect(1).toBe(1);
-    });
+  it('Sample test', () => {
+    expect(1).toBe(1);
+  });
 });


### PR DESCRIPTION
## Task
- https://github.com/Vin-it/declutter-reddit/projects/1#card-60204143
 
## Changes
- Made init functions consistent
- Renamed `getKnexInstance` before calling to make it more readable
- Added legacy watch mode for nodemon (docker issues)