### PR TITLE
DR-19 Run migrations from the server, remove docker migration service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,19 +11,11 @@ services:
             - "9229:9229"
         depends_on: 
             - db-reddit
-            - migration
         environment: 
             - DB_HOST=db-reddit
             - DEBUG=debug*
             - NODE_ENV=development
         tty: true
-    migration:
-        build: .
-        command: ./wait-for-it/wait-for-it.sh -t 60 db-reddit:3306 -- ./node_modules/.bin/knex --knexfile ./lib/database/knexfile.js migrate:latest
-        depends_on: 
-            - db-reddit
-        environment: 
-            - DB_HOST=db-reddit
     db-reddit:
         image: mysql
         command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
## Task
- https://github.com/Vin-it/declutter-reddit/projects/1#card-56864202

## Changes
- Removed migration service from `docker-compose` 
- Added `initMigration` function to run migrations from the express server