### PR TITLE
DR-32 Add retry logic for migrations

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -18,13 +18,18 @@ function initMiddlewares(app) {
   app.use(router);
 }
 
-async function initMigrations(knex) {
+async function initMigrations(knex, retryCount) {
+  if (retryCount === 3) {
+    throw Error('Failed to run migrations after 3 retries');
+  }
+
   return knex.migrate.latest({
     directory: 'lib/database/migrations',
   }).then(() => {
     logDatabase('Migrations ran succcessfully');
   }).catch((error) => {
-    logDatabase('Error running migrations', error.message);
+    logDatabase('Error running migrations, retrying in 10 seconds...', error.message);
+    setTimeout(() => initMigrations(knex, retryCount + 1), 10000);
   });
 }
 
@@ -36,7 +41,7 @@ async function initApp() {
   initDebug();
   initKnex();
   initObjection(knex());
-  await initMigrations(knex());
+  await initMigrations(knex(), 0);
   initMiddlewares(app);
 
   app.listen(PORT, () => {


### PR DESCRIPTION
## Task
- https://github.com/Vin-it/declutter-reddit/projects/1#card-60265991

## Changes
- Added retry logic for running migrations if the migrations run before database is initialized