### PR TITLE
DR-27 Centralized error handler (middleware), error constants

### DIFF
--- a/lib/constants/errors/codes.js
+++ b/lib/constants/errors/codes.js
@@ -1,0 +1,5 @@
+module.exports = {
+  SERVER_ERROR: 'SERVER_ERROR',
+  INSERT_FAIL: 'INSERT_FAIL',
+  USER_NOT_FOUND: 'USER_NOT_FOUND',
+};

--- a/lib/constants/errors/index.js
+++ b/lib/constants/errors/index.js
@@ -1,3 +1,6 @@
+const codes = require('./codes');
+
 module.exports = {
   REDDIT_REQUEST_ERR_MESSAGE: 'Error while making a request to reddit',
+  codes,
 };

--- a/lib/middleware/error-handler.js
+++ b/lib/middleware/error-handler.js
@@ -1,0 +1,19 @@
+const { logServer } = require('../utils/debug');
+
+function defaultErrorHandler(error, req, res) {
+  logServer('defaultErrorHandler', error.message);
+
+  if (error.expose) {
+    res.json({
+      success: false,
+      message: error.message,
+    });
+  } else {
+    res.json({
+      success: false,
+      message: 'Something went wrong',
+    });
+  }
+}
+
+module.exports = defaultErrorHandler;

--- a/lib/routes/auth/post-login.js
+++ b/lib/routes/auth/post-login.js
@@ -1,21 +1,15 @@
+const config = require('config');
+
 const { getUserByUsername, updateAccessToken } = require('../../queries/users');
 const { refreshAccessToken } = require('../../services/reddit');
 const { calcExpiresOn } = require('../../utils/date');
 const { logDatabase, logRequest } = require('../../utils/debug');
+const makeError = require('../../utils/make-error');
 
-function handleError(error, res) {
-  if (error.expose) {
-    res.json({
-      success: false,
-      message: error.message,
-    });
-  } else {
-    res.json({
-      success: false,
-      message: 'something went wrong',
-    });
-  }
-}
+const {
+  USER_NOT_FOUND,
+  INSERT_FAIL,
+} = config.get('errors.codes');
 
 async function handleExpiredAccessToken(user, username) {
   const response = await refreshAccessToken(user);
@@ -24,10 +18,13 @@ async function handleExpiredAccessToken(user, username) {
   const updatedToken = await updateAccessToken(response.data.access_token, expiresOn, username);
 
   if (!updatedToken) {
-    const error = new Error('Failed to insert refreshed access token into the database');
-    error.status = 500;
-    error.expose = false;
-    error.code = 'INSERT_FAIL';
+    const error = makeError({
+      message: 'Failed to insert refreshed access token into the database',
+      status: 500,
+      expose: false,
+      code: INSERT_FAIL,
+    });
+
     throw error;
   }
 
@@ -38,17 +35,20 @@ async function handleGetUser(username) {
   const [user] = (await getUserByUsername(username));
 
   if (!user) {
-    const error = new Error('Incorrect combination of username and password');
-    error.status = 404;
-    error.code = 'USER_NOT_FOUND';
-    error.expose = true;
+    const error = makeError({
+      message: 'Incorrect combination of username and password',
+      status: 404,
+      code: USER_NOT_FOUND,
+      expose: true,
+    });
+
     throw error;
   }
 
   return user;
 }
 
-async function postLogin(req, res) {
+async function postLogin(req, res, next) {
   const { username } = req.body;
 
   let user = null;
@@ -57,7 +57,7 @@ async function postLogin(req, res) {
     user = await handleGetUser(username);
   } catch (error) {
     logDatabase('Error while getting the user', error.message);
-    handleError(error, res);
+    next(error);
     return { success: false };
   }
 
@@ -80,7 +80,7 @@ async function postLogin(req, res) {
       };
     } catch (error) {
       logRequest('Error while handling expired access token', error.message);
-      handleError(error, res);
+      next(error);
       return { success: false };
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,7 @@ const { init: initKnex, getInstance: getKnexInstance } = require('./database/kne
 const { init: initObjection } = require('./database/objection');
 const { init: initDebug, logServer, logDatabase } = require('./utils/debug');
 const router = require('./router');
+const errorHandler = require('./middleware/error-handler');
 
 function initMiddlewares(app) {
   const knex = getKnexInstance();
@@ -23,6 +24,7 @@ function initMiddlewares(app) {
   }));
   app.use('/static', express.static(path.join(__dirname, '../public')));
   app.use(router);
+  app.use(errorHandler);
 }
 
 async function initMigrations(knex, retryCount) {

--- a/lib/utils/make-error.js
+++ b/lib/utils/make-error.js
@@ -1,0 +1,20 @@
+const config = require('config');
+
+const { SERVER_ERROR } = config.get('errors.codes');
+
+function makeError(errorObject = {
+  message: 'Something went wrong!',
+  status: 500,
+  expose: false,
+  code: SERVER_ERROR,
+}) {
+  let error = new Error(errorObject.message);
+  error = {
+    ...error,
+    ...errorObject,
+  };
+
+  return error;
+}
+
+module.exports = makeError;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5675,9 +5675,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.6.1",
+    "lodash": "^4.17.21",
     "nodemon": "^2.0.6"
   }
 }

--- a/test/unit/__mocks__/config.js
+++ b/test/unit/__mocks__/config.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const constants = require('../../../config/default');
 
 const config = {
@@ -11,6 +13,6 @@ const config = {
   },
 };
 module.exports = {
-  get: (prop) => (config[prop]),
+  get: (path) => (_.get(config, path)),
   config,
 };


### PR DESCRIPTION
## Task
- https://github.com/Vin-it/declutter-reddit/projects/1#card-56333233

## Changes
- Added custom error code constants
- Moved error constants to a folder (Here you can see why using `config` is worth the trouble, no need to manage complicated paths)
- Added a centralized error handler (middleware)
- Created a makeError function to keep all errors consistent
- Added `lodash` for `config` package tests
- Update tests