### PR TITLE
DR-42 Webpack cleanup, move react app, move main component to it's own file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,11 @@
             }
           }
         ],
-        "@babel/react"
+        [
+          "@babel/react",
+          {
+            "runtime": "automatic"
+          }
+        ]
     ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,9 @@ module.exports = {
   plugins: [
     'react',
   ],
-  ignorePatterns: ["lib/database/migrations"],
+  rules: {
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off',
+  },
+  ignorePatterns: ['lib/database/migrations'],
 };

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -1,0 +1,5 @@
+function Main() {
+  return <h1>I am a React app</h1>;
+}
+
+export default Main;

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,0 +1,5 @@
+import ReactDOM from 'react-dom';
+
+import Main from './components/Main';
+
+ReactDOM.render(<Main />, document.getElementById('root'));

--- a/public/assets/js/index.jsx
+++ b/public/assets/js/index.jsx
@@ -1,8 +1,0 @@
-import ReactDOM from 'react-dom';
-import React from 'react';
-
-function Hello() {
-  return <h1>I am a React app!</h1>;
-}
-
-ReactDOM.render(<Hello />, document.getElementById('root'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,12 +3,15 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
-  entry: './public/assets/js/index.jsx',
+  entry: './client/index.jsx',
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'views', 'index.ejs'),
     }),
   ],
+  resolve: {
+    extensions: ['.jsx', '.js'],
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
## Task

## Changes
- Added `runtime: automatic` for avoiding `React` imports at the top of `.jsx` files
- Updated `eslintrc` to not enforce the above rule
- Moved React app to the `client` folder
- Updated webpack to resolve `.jsx` and `.js` in imports automatically
- Moved react app to the client, and moved Main component to it's own file